### PR TITLE
Fix setting number of HPX worker threads with gprat.start_hpx

### DIFF
--- a/bindings/utils_py.cpp
+++ b/bindings/utils_py.cpp
@@ -15,7 +15,8 @@ namespace py = pybind11;
 void start_hpx_wrapper(std::vector<std::string> args, std::size_t n_cores)
 {
     // If args is empty, set the first argument to "gprat"
-    if (args.empty()) {
+    if (args.empty())
+    {
         args.push_back("gprat");
     }
 

--- a/bindings/utils_py.cpp
+++ b/bindings/utils_py.cpp
@@ -14,6 +14,11 @@ namespace py = pybind11;
  */
 void start_hpx_wrapper(std::vector<std::string> args, std::size_t n_cores)
 {
+    // If args is empty, set the first argument to "gprat"
+    if (args.empty()) {
+        args.push_back("gprat");
+    }
+
     // Add the --hpx:threads argument to the args vector
     args.push_back("--hpx:threads=" + std::to_string(n_cores));
 


### PR DESCRIPTION
- HPX interprets first argument as program name
- if args does not contain an argument, the added argument for setting the number of OS threads is ignored